### PR TITLE
remove duplicate function Vvveb\session from /component/form.php

### DIFF
--- a/component/form.php
+++ b/component/form.php
@@ -26,7 +26,6 @@ use function Vvveb\__;
 use function Vvveb\session;
 use function Vvveb\email;
 use function Vvveb\humanReadable;
-use function Vvveb\session;
 use function Vvveb\siteSettings;
 use Vvveb\Sql\Plugins\ContactForm\MessageSQL;
 use Vvveb\System\Core\Request;


### PR DESCRIPTION
`Fatal error: Cannot use function Vvveb\session as session because the name is already in use in G:\laragon-6.0.0\www\Vvveb\plugins\contact-form\component\form.php on line 29`

In `component/form.php` there was a duplicate `use function Vvveb\session` on line 29, so I removed it.